### PR TITLE
Extend export options

### DIFF
--- a/src/Csv.cpp
+++ b/src/Csv.cpp
@@ -103,8 +103,7 @@ QString Csv::writeSelectionToString(QAbstractItemModel *model, const QItemSelect
             QStringList rowContents;
             for (auto col = range.left(); col <= range.right(); ++col)
             {
-                QVariant value = model->index(row, col).data();
-                rowContents << escape(value.isNull() ? "" : value.toString());
+                rowContents << processValue(model->index(row, col).data());
             }
             text += rowContents.join(m_delimiter);
             text += "\n";

--- a/src/Csv.h
+++ b/src/Csv.h
@@ -8,11 +8,14 @@
 #include <QSqlQuery>
 #include <QSqlField>
 #include <QSqlRecord>
+#include <QDate>
+#include <QDateTime>
+#include <QTime>
 
 class Csv
 {
 public:
-    Csv(QString delimiter = ",", QString quote = "\"");
+    Csv(QString delimiter = ",", QString quote = "\"", bool includeHeader = true, bool quoteStringColumns = true, QLocale locale = QLocale::system(), QHash<QString, QString> formatOverrides = QHash<QString, QString>());
     void write(QTextStream *stream, QAbstractItemModel *model);
     void write(QTextStream *stream, QSqlQuery *query, bool* stopFlag);
     QString writeSelectionToString(QAbstractItemModel *model, const QItemSelection &selection, bool includeHeaders = true);
@@ -20,7 +23,16 @@ public:
 private:
     QString m_delimiter;
     QString m_quote;
-    QString escape(QString value);
+    bool m_includeHeader;
+    QLocale m_locale;
+    bool m_quoteStringColumns;
+
+    QString m_timeFormat;
+    QString m_timestampFormat;
+    QString m_dateFormat;
+
+    QString escape(QString value, bool quoteStringData = true);
+    QString processValue(QVariant value);
 };
 
 #endif // CSV_H

--- a/ui/ExportQueryDialog.cpp
+++ b/ui/ExportQueryDialog.cpp
@@ -146,6 +146,21 @@ void ExportQueryDialog::on_checkBoxStateChanged(int)
 
 void ExportQueryDialog::on_checkBoxToggled(bool)
 {
+    /* ugly hack; i guess here is needed a custom QTextBox or whatever */
+    QLocale selectedLocale = ui->combobox_locale->currentData(Qt::UserRole+1).value<QLocale>();
+
+    ui->textbox_decimalSeparator->setText(selectedLocale.decimalPoint());
+    ui->textbox_thousandSeparator->setText(selectedLocale.groupSeparator());
+
+    if (!ui->checkbox_customDateFormat->isChecked())
+        ui->combobox_dateFormat->setCurrentText(selectedLocale.dateFormat(QLocale::ShortFormat));
+
+    if (!ui->checkbox_customTimeFormat->isChecked())
+        ui->combobox_timeFormat->setCurrentText(selectedLocale.timeFormat(QLocale::ShortFormat));
+
+    if (!ui->checkbox_customTimestampFormat->isChecked())
+        ui->combobox_timestampFormat->setCurrentText(selectedLocale.dateTimeFormat(QLocale::ShortFormat));
+
     refreshText();
 }
 

--- a/ui/ExportQueryDialog.cpp
+++ b/ui/ExportQueryDialog.cpp
@@ -74,6 +74,7 @@ ExportQueryDialog::ExportQueryDialog(QStandardItemModel* model, QWidget *parent)
 
     ui->checkbox_includeHeader->setChecked(settings.value("includeHeader", true).toBool());
     ui->checkbox_quoteStringColumns->setChecked(settings.value("quoteStringColumns", true).toBool());
+    ui->linedit_outputFilePath->setText(settings.value("lastFile", "").toString());
 
     settings.endGroup();
 
@@ -248,6 +249,8 @@ void ExportQueryDialog::on_buttonBox_accepted()
 
     settings.setValue("includeHeader", ui->checkbox_includeHeader->isChecked());
     settings.setValue("quoteStringColumns", ui->checkbox_quoteStringColumns->isChecked());
+
+    settings.setValue("lastFile", ui->linedit_outputFilePath->text());
 
     settings.endGroup();
 }

--- a/ui/ExportQueryDialog.cpp
+++ b/ui/ExportQueryDialog.cpp
@@ -155,10 +155,14 @@ void ExportQueryDialog::refreshText()
 
     ui->textbox_preview->clear();
 
-    QLocale selectedLocale = ui->combobox_locale->currentData().value<QLocale>();
+    int index = ui->combobox_locale->currentIndex();
+
+    QLocale selectedLocale = ui->combobox_locale->itemData(index, Qt::UserRole+1).value<QLocale>();
 
     bool quoteStringColumns = ui->checkbox_quoteStringColumns->isChecked();
     bool includeHeader = ui->checkbox_includeHeader->isChecked();
+
+    //qDebug() << "using format: " + formatOverrides()["dateFormat"];
 
     Csv csv(delimiter, quoteSymbol, includeHeader, quoteStringColumns, selectedLocale, formatOverrides());
 
@@ -173,7 +177,10 @@ void ExportQueryDialog::on_checkBoxStateChanged(int)
 void ExportQueryDialog::on_checkBoxToggled(bool)
 {
     /* ugly hack; i guess here is needed a custom QTextBox or whatever */
-    QLocale selectedLocale = ui->combobox_locale->currentData(Qt::UserRole+1).value<QLocale>();
+
+    int index = ui->combobox_locale->currentIndex();
+
+    QLocale selectedLocale = ui->combobox_locale->itemData(index, Qt::UserRole+1).value<QLocale>();
 
     ui->textbox_decimalSeparator->setText(selectedLocale.decimalPoint());
     ui->textbox_thousandSeparator->setText(selectedLocale.groupSeparator());
@@ -202,7 +209,7 @@ void ExportQueryDialog::on_comboboxCurrentIndexChanged(int)
 
 void ExportQueryDialog::on_combobox_locale_currentIndexChanged(int index)
 {
-    QLocale selectedLocale = ui->combobox_locale->itemData(index).value<QLocale>();
+    QLocale selectedLocale = ui->combobox_locale->itemData(index, Qt::UserRole+1).value<QLocale>();
 
     ui->textbox_decimalSeparator->setText(selectedLocale.decimalPoint());
     ui->textbox_thousandSeparator->setText(selectedLocale.groupSeparator());

--- a/ui/ExportQueryDialog.cpp
+++ b/ui/ExportQueryDialog.cpp
@@ -7,7 +7,7 @@ ExportQueryDialog::ExportQueryDialog(QStandardItemModel* model, QWidget *parent)
     m_model(model)
 {
     ui->setupUi(this);
-    ui->textedit_preview->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+    ui->textbox_preview->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
     ui->buttonBox->button(QDialogButtonBox::Ok)->setDisabled(true);
 
     connect(ui->linedit_outputFilePath, &QLineEdit::textChanged, this, &ExportQueryDialog::checkFilename);
@@ -16,7 +16,30 @@ ExportQueryDialog::ExportQueryDialog(QStandardItemModel* model, QWidget *parent)
     connect(ui->combobox_delimiter, SIGNAL(currentTextChanged(QString)), this, SLOT(on_comboboxCurrentTextChanged(QString)));
     connect(ui->combobox_quote, SIGNAL(currentIndexChanged(int)), this, SLOT(on_comboboxCurrentIndexChanged(int)));
     connect(ui->combobox_quote, SIGNAL(currentTextChanged(QString)), this, SLOT(on_comboboxCurrentTextChanged(QString)));
+    connect(ui->combobox_dateFormat, SIGNAL(currentIndexChanged(int)), this, SLOT(on_comboboxCurrentIndexChanged(int)));
+    connect(ui->combobox_dateFormat, SIGNAL(currentTextChanged(QString)), this, SLOT(on_comboboxCurrentTextChanged(QString)));
+    connect(ui->combobox_locale, SIGNAL(currentIndexChanged(int)), this, SLOT(on_comboboxCurrentIndexChanged(int)));
+    connect(ui->combobox_locale, SIGNAL(currentTextChanged(QString)), this, SLOT(on_comboboxCurrentTextChanged(QString)));
+    connect(ui->combobox_timeFormat, SIGNAL(currentIndexChanged(int)), this, SLOT(on_comboboxCurrentIndexChanged(int)));
+    connect(ui->combobox_timeFormat, SIGNAL(currentTextChanged(QString)), this, SLOT(on_comboboxCurrentTextChanged(QString)));
+    connect(ui->combobox_timestampFormat, SIGNAL(currentIndexChanged(int)), this, SLOT(on_comboboxCurrentIndexChanged(int)));
+    connect(ui->combobox_timestampFormat, SIGNAL(currentTextChanged(QString)), this, SLOT(on_comboboxCurrentTextChanged(QString)));
+    connect(ui->combobox_quote, SIGNAL(currentTextChanged(QString)), this, SLOT(on_comboboxCurrentTextChanged(QString)));
     connect(ui->checkbox_includeHeader, &QCheckBox::stateChanged, this, &ExportQueryDialog::on_checkBoxStateChanged);
+
+    QMap<QString, QLocale> allLocales;
+
+    foreach (QLocale locale, QLocale::matchingLocales(QLocale::AnyLanguage, QLocale::AnyScript, QLocale::AnyCountry))
+    {
+        allLocales[QLocale::countryToString(locale.country()) + " (" + locale.name() + ")"] = locale;
+    }
+
+    ui->combobox_locale->addItem("<system locale>", QLocale::system());
+
+    foreach(QString key, allLocales.keys())
+    {
+        ui->combobox_locale->addItem(key, allLocales[key]);
+    }
 
     refreshText();
 }
@@ -47,6 +70,20 @@ QString ExportQueryDialog::quoteSymbol()
     return ui->combobox_quote->currentText();
 }
 
+QHash<QString, QString> ExportQueryDialog::formatOverrides()
+{
+    QHash<QString, QString> formatOverrides;
+
+    if (ui->checkbox_customDateFormat->isChecked())
+        formatOverrides["dateformat"] = ui->combobox_dateFormat->currentText();
+    if (ui->checkbox_customTimeFormat->isChecked())
+        formatOverrides["timeformat"] = ui->combobox_timeFormat->currentText();
+    if (ui->checkbox_customTimestampFormat->isChecked())
+        formatOverrides["timestampformat"] = ui->combobox_timestampFormat->currentText();
+
+    return formatOverrides;
+}
+
 void ExportQueryDialog::on_linedit_outputFilePath_textChanged(const QString &arg1)
 {
     if (!arg1.isEmpty())
@@ -65,11 +102,18 @@ void ExportQueryDialog::refreshText()
     QString delimiter = ui->combobox_delimiter->currentText();
     QString quoteSymbol = ui->combobox_delimiter->currentText();
 
-    ui->textedit_preview->clear();
+    ui->textbox_preview->clear();
 
     Csv csv(delimiter, quoteSymbol);
 
-    ui->textedit_preview->appendPlainText(csv.writeSelectionToString(m_model, ui->checkbox_includeHeader->isChecked(), 10));
+    //QString numberFormat = ui->combobox_numberFormat->currentText();
+    QString dateFormat = ui->combobox_dateFormat->currentText();
+    QString timestampFormat = ui->combobox_timestampFormat->currentText();
+    QString timeFormat = ui->combobox_timeFormat->currentText();
+
+    //numberFormat = "%+06.2f";
+
+    ui->textbox_preview->appendPlainText(csv.writeSelectionToString(m_model, ui->checkbox_includeHeader->isChecked(), 10));
 }
 
 void ExportQueryDialog::on_checkBoxStateChanged(int)
@@ -82,8 +126,27 @@ void ExportQueryDialog::on_comboboxCurrentTextChanged(QString)
     refreshText();
 }
 
-
 void ExportQueryDialog::on_comboboxCurrentIndexChanged(int)
 {
     refreshText();
+}
+
+void ExportQueryDialog::on_combobox_locale_currentIndexChanged(int index)
+{
+    QLocale selectedLocale = ui->combobox_locale->itemData(index).value<QLocale>();
+
+    ui->textbox_decimalSeparator->setText(selectedLocale.decimalPoint());
+    ui->textbox_thousandSeparator->setText(selectedLocale.groupSeparator());
+
+    ui->combobox_dateFormat->removeItem(0);
+    ui->combobox_dateFormat->insertItem(0, selectedLocale.dateFormat(QLocale::ShortFormat));
+    ui->combobox_dateFormat->setCurrentIndex(0);
+
+    ui->combobox_timestampFormat->removeItem(0);
+    ui->combobox_timestampFormat->insertItem(0, selectedLocale.dateTimeFormat(QLocale::ShortFormat));
+    ui->combobox_timestampFormat->setCurrentIndex(0);
+
+    ui->combobox_timeFormat->removeItem(0);
+    ui->combobox_timeFormat->insertItem(0, selectedLocale.timeFormat(QLocale::ShortFormat));
+    ui->combobox_timeFormat->setCurrentIndex(0);
 }

--- a/ui/ExportQueryDialog.cpp
+++ b/ui/ExportQueryDialog.cpp
@@ -51,6 +51,32 @@ ExportQueryDialog::ExportQueryDialog(QStandardItemModel* model, QWidget *parent)
         ui->combobox_locale->addItem(key, allLocales[key]);
     }
 
+    QSettings settings(QSettings::IniFormat, QSettings::UserScope, QApplication::applicationName(), "settings");
+    settings.beginGroup("Export");
+
+    if (settings.contains("dateFormat"))
+    {
+        ui->checkbox_customDateFormat->setChecked(true);
+        ui->combobox_dateFormat->setCurrentText(settings.value("dateFormat").toString());
+    }
+
+    if (settings.contains("timeFormat"))
+    {
+        ui->checkbox_customTimeFormat->setChecked(true);
+        ui->combobox_timeFormat->setCurrentText(settings.value("timeFormat").toString());
+    }
+
+    if (settings.contains("timestampFormat"))
+    {
+        ui->checkbox_customTimestampFormat->setChecked(true);
+        ui->combobox_timestampFormat->setCurrentText(settings.value("timestampFormat").toString());
+    }
+
+    ui->checkbox_includeHeader->setChecked(settings.value("includeHeader", true).toBool());
+    ui->checkbox_quoteStringColumns->setChecked(settings.value("quoteStringColumns", true).toBool());
+
+    settings.endGroup();
+
     refreshText();
 }
 
@@ -191,4 +217,30 @@ void ExportQueryDialog::on_combobox_locale_currentIndexChanged(int index)
         ui->combobox_timestampFormat->setCurrentText(selectedLocale.dateTimeFormat(QLocale::ShortFormat));
 
     refreshText();
+}
+
+void ExportQueryDialog::on_buttonBox_accepted()
+{
+    QSettings settings(QSettings::IniFormat, QSettings::UserScope, QApplication::applicationName(), "settings");
+    settings.beginGroup("Export");
+
+    if (ui->checkbox_customDateFormat->isChecked() &&  !ui->combobox_dateFormat->currentText().isEmpty())
+        settings.setValue("dateFormat", ui->combobox_dateFormat->currentText());
+    else
+        settings.remove("dateFormat");
+
+    if (ui->checkbox_customTimestampFormat->isChecked() && !ui->combobox_timestampFormat->currentText().isEmpty())
+        settings.setValue("timestampFormat", ui->combobox_timestampFormat->currentText());
+    else
+        settings.remove("timestampFormat");
+
+    if (ui->checkbox_customTimeFormat->isChecked() && !ui->combobox_timeFormat->currentText().isEmpty())
+        settings.setValue("timeFormat", ui->combobox_timeFormat->currentText());
+    else
+        settings.remove("timeFormat");
+
+    settings.setValue("includeHeader", ui->checkbox_includeHeader->isChecked());
+    settings.setValue("quoteStringColumns", ui->checkbox_quoteStringColumns->isChecked());
+
+    settings.endGroup();
 }

--- a/ui/ExportQueryDialog.h
+++ b/ui/ExportQueryDialog.h
@@ -24,6 +24,8 @@ public:
     QString outputFilePath();
     QString delimiter();
     QString quoteSymbol();
+    QLocale locale();
+    QHash<QString, QString> formatOverrides();
 
 public slots:
     void checkFilename(const QString text);
@@ -34,6 +36,8 @@ public slots:
 private slots:
     void on_pushButton_released();
     void on_linedit_outputFilePath_textChanged(const QString &arg1);
+
+    void on_combobox_locale_currentIndexChanged(int index);
 
 private:
     Ui::ExportQueryDialog *ui;

--- a/ui/ExportQueryDialog.h
+++ b/ui/ExportQueryDialog.h
@@ -9,6 +9,7 @@
 #include <QFileDialog>
 #include <QFontDatabase>
 #include <QStandardItemModel>
+#include <QSettings>
 
 namespace Ui {
 class ExportQueryDialog;
@@ -42,6 +43,8 @@ private slots:
     void on_linedit_outputFilePath_textChanged(const QString &arg1);
 
     void on_combobox_locale_currentIndexChanged(int index);
+
+    void on_buttonBox_accepted();
 
 private:
     Ui::ExportQueryDialog *ui;

--- a/ui/ExportQueryDialog.h
+++ b/ui/ExportQueryDialog.h
@@ -41,9 +41,6 @@ public slots:
 private slots:
     void on_pushButton_released();
     void on_linedit_outputFilePath_textChanged(const QString &arg1);
-
-    void on_combobox_locale_currentIndexChanged(int index);
-
     void on_buttonBox_accepted();
 
 private:
@@ -51,6 +48,8 @@ private:
     QString m_outputFilePath;
 
     QStandardItemModel* m_model;
+
+    QLocale m_locale;
 
     void refreshText();
 };

--- a/ui/ExportQueryDialog.h
+++ b/ui/ExportQueryDialog.h
@@ -3,6 +3,7 @@
 
 #include "src/Csv.h"
 
+#include <QDebug>
 #include <QAbstractButton>
 #include <QDialog>
 #include <QFileDialog>
@@ -26,10 +27,13 @@ public:
     QString quoteSymbol();
     QLocale locale();
     QHash<QString, QString> formatOverrides();
+    bool includeHeader();
+    bool quoteStringColumns();
 
 public slots:
     void checkFilename(const QString text);
     void on_checkBoxStateChanged(int);
+    void on_checkBoxToggled(bool);
     void on_comboboxCurrentIndexChanged(int);
     void on_comboboxCurrentTextChanged(QString);
 

--- a/ui/ExportQueryDialog.ui
+++ b/ui/ExportQueryDialog.ui
@@ -93,6 +93,11 @@
             <string>|</string>
            </property>
           </item>
+          <item>
+           <property name="text">
+            <string>&lt;tab&gt;</string>
+           </property>
+          </item>
          </widget>
         </item>
         <item row="2" column="0">
@@ -160,27 +165,7 @@
         <string>Formats</string>
        </property>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="4" column="3">
-         <widget class="QComboBox" name="combobox_timeFormat">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="editable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLabel" name="label_8">
-          <property name="text">
-           <string>Locale</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="3">
-         <widget class="QComboBox" name="combobox_locale"/>
-        </item>
-        <item row="2" column="3">
+        <item row="1" column="3">
          <widget class="QComboBox" name="combobox_dateFormat">
           <property name="enabled">
            <bool>false</bool>
@@ -190,45 +175,49 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="3">
-         <widget class="QComboBox" name="combobox_timestampFormat">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="editable">
-           <bool>true</bool>
+        <item row="2" column="1">
+         <widget class="QCheckBox" name="checkbox_customTimestampFormat">
+          <property name="text">
+           <string>Custom timestamp format</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="3">
+        <item row="4" column="3">
          <widget class="QLineEdit" name="textbox_decimalSeparator">
           <property name="enabled">
            <bool>false</bool>
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Decimal separator</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="3">
+        <item row="5" column="3">
          <widget class="QLineEdit" name="textbox_thousandSeparator">
           <property name="enabled">
            <bool>false</bool>
           </property>
          </widget>
         </item>
-        <item row="6" column="1">
+        <item row="3" column="1">
+         <widget class="QCheckBox" name="checkbox_customTimeFormat">
+          <property name="text">
+           <string>Custom time format</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
          <widget class="QLabel" name="label_9">
           <property name="text">
            <string>Thousand separator</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="4" column="1">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Decimal separator</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
          <widget class="QCheckBox" name="checkbox_customDateFormat">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -241,17 +230,23 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
-         <widget class="QCheckBox" name="checkbox_customTimestampFormat">
-          <property name="text">
-           <string>Custom timestamp format</string>
+        <item row="3" column="3">
+         <widget class="QComboBox" name="combobox_timeFormat">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="editable">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
-         <widget class="QCheckBox" name="checkbox_customTimeFormat">
-          <property name="text">
-           <string>Custom time format</string>
+        <item row="2" column="3">
+         <widget class="QComboBox" name="combobox_timestampFormat">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="editable">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -286,6 +281,13 @@
       <widget class="QLabel" name="label_error">
        <property name="text">
         <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Note: decimal separator and thousand separator are based on system locale</string>
        </property>
       </widget>
      </item>

--- a/ui/ExportQueryDialog.ui
+++ b/ui/ExportQueryDialog.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>597</width>
-    <height>525</height>
+    <width>698</width>
+    <height>534</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Export data</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -29,103 +29,272 @@
     </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Export options</string>
-     </property>
-     <property name="flat">
-      <bool>true</bool>
-     </property>
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Delimiter</string>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="title">
+        <string>Export options</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <layout class="QFormLayout" name="formLayout">
+        <property name="fieldGrowthPolicy">
+         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
         </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="combobox_delimiter">
-        <property name="minimumSize">
-         <size>
-          <width>80</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="editable">
-         <bool>true</bool>
-        </property>
-        <item>
-         <property name="text">
-          <string>;</string>
-         </property>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Delimiter</string>
+          </property>
+         </widget>
         </item>
-        <item>
-         <property name="text">
-          <string>,</string>
-         </property>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="combobox_delimiter">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="editable">
+           <bool>true</bool>
+          </property>
+          <item>
+           <property name="text">
+            <string>;</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>,</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>|</string>
+           </property>
+          </item>
+         </widget>
         </item>
-        <item>
-         <property name="text">
-          <string>|</string>
-         </property>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Quote with</string>
+          </property>
+         </widget>
         </item>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="combobox_quote">
-        <property name="minimumSize">
-         <size>
-          <width>80</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="editable">
-         <bool>true</bool>
-        </property>
-        <item>
-         <property name="text">
-          <string>&quot;</string>
-         </property>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="combobox_quote">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="editable">
+           <bool>true</bool>
+          </property>
+          <item>
+           <property name="text">
+            <string>&quot;</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>'</string>
+           </property>
+          </item>
+         </widget>
         </item>
-        <item>
-         <property name="text">
-          <string>'</string>
-         </property>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Include header</string>
+          </property>
+         </widget>
         </item>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Quote with</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="checkbox_includeHeader">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Include header</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+        <item row="3" column="1">
+         <widget class="QCheckBox" name="checkbox_includeHeader">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="minimumSize">
+        <size>
+         <width>300</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="title">
+        <string>Formats</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="4" column="3">
+         <widget class="QComboBox" name="combobox_timeFormat">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="editable">
+           <bool>true</bool>
+          </property>
+          <item>
+           <property name="text">
+            <string/>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>HH:mm</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>HH:mm:ss</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string>Locale</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3">
+         <widget class="QComboBox" name="combobox_locale"/>
+        </item>
+        <item row="2" column="3">
+         <widget class="QComboBox" name="combobox_dateFormat">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="editable">
+           <bool>true</bool>
+          </property>
+          <item>
+           <property name="text">
+            <string/>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>yyyy-MM-dd</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="3" column="3">
+         <widget class="QComboBox" name="combobox_timestampFormat">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="editable">
+           <bool>true</bool>
+          </property>
+          <item>
+           <property name="text">
+            <string/>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>yyyy-MM-dd HH:mm:ss</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>yyyy-MM-ddTHH:mm:ss</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="5" column="3">
+         <widget class="QLineEdit" name="textbox_decimalSeparator">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Decimal separator</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="3">
+         <widget class="QLineEdit" name="textbox_thousandSeparator">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>Thousand separator</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QCheckBox" name="checkbox_customDateFormat">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Custom date format</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QCheckBox" name="checkbox_customTimestampFormat">
+          <property name="text">
+           <string>Custom timestamp format</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QCheckBox" name="checkbox_customTimeFormat">
+          <property name="text">
+           <string>Custom time format</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QPlainTextEdit" name="textedit_preview">
+      <widget class="QPlainTextEdit" name="textbox_preview">
        <property name="acceptDrops">
         <bool>false</bool>
        </property>

--- a/ui/ExportQueryDialog.ui
+++ b/ui/ExportQueryDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>698</width>
-    <height>534</height>
+    <width>860</width>
+    <height>663</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -33,15 +33,21 @@
      <item>
       <widget class="QGroupBox" name="groupBox">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
        <property name="minimumSize">
         <size>
-         <width>0</width>
+         <width>300</width>
          <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>400</width>
+         <height>16777215</height>
         </size>
        </property>
        <property name="title">
@@ -119,17 +125,20 @@
           </item>
          </widget>
         </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Include header</string>
-          </property>
-         </widget>
-        </item>
         <item row="3" column="1">
          <widget class="QCheckBox" name="checkbox_includeHeader">
           <property name="text">
-           <string/>
+           <string>Include header</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QCheckBox" name="checkbox_quoteStringColumns">
+          <property name="text">
+           <string>Quote string columns</string>
           </property>
           <property name="checked">
            <bool>true</bool>
@@ -154,26 +163,11 @@
         <item row="4" column="3">
          <widget class="QComboBox" name="combobox_timeFormat">
           <property name="enabled">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
           <property name="editable">
            <bool>true</bool>
           </property>
-          <item>
-           <property name="text">
-            <string/>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>HH:mm</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>HH:mm:ss</string>
-           </property>
-          </item>
          </widget>
         </item>
         <item row="0" column="1">
@@ -189,46 +183,21 @@
         <item row="2" column="3">
          <widget class="QComboBox" name="combobox_dateFormat">
           <property name="enabled">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
           <property name="editable">
            <bool>true</bool>
           </property>
-          <item>
-           <property name="text">
-            <string/>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>yyyy-MM-dd</string>
-           </property>
-          </item>
          </widget>
         </item>
         <item row="3" column="3">
          <widget class="QComboBox" name="combobox_timestampFormat">
           <property name="enabled">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
           <property name="editable">
            <bool>true</bool>
           </property>
-          <item>
-           <property name="text">
-            <string/>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>yyyy-MM-dd HH:mm:ss</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>yyyy-MM-ddTHH:mm:ss</string>
-           </property>
-          </item>
          </widget>
         </item>
         <item row="5" column="3">

--- a/ui/QueryTab.cpp
+++ b/ui/QueryTab.cpp
@@ -372,8 +372,9 @@ void QueryTab::on_button_exportQueryResults_released()
         if (filename.isEmpty() || !m_query->isFinished() || !m_query->isSelect())
             return;
 
-        //Csv(QString delimiter = ",", QString quote = "\"", bool includeHeader = true, bool quoteStringColumns = true, QLocale locale = QLocale::system(), QHash<QString, QString> formatOverrides = QHash<QString, QString>());
-        Csv csv(dialog.delimiter(), dialog.quoteSymbol(), dialog.includeHeader(), dialog.quoteStringColumns(), dialog.locale(), dialog.formatOverrides());
+        QString delimiter = dialog.delimiter() == "<tab>" ? "\t" : dialog.delimiter();
+
+        Csv csv(delimiter, dialog.quoteSymbol(), dialog.includeHeader(), dialog.quoteStringColumns(), dialog.locale(), dialog.formatOverrides());
 
         ui->button_exportQueryResults->setEnabled(false);
         ui->button_stopExport->setEnabled(true);

--- a/ui/QueryTab.cpp
+++ b/ui/QueryTab.cpp
@@ -367,15 +367,13 @@ void QueryTab::on_button_exportQueryResults_released()
     if (dialog.exec() == QDialog::Accepted)
     {
         QString filename = dialog.outputFilePath();
-        //QString numberFormat = dialog.numberFormat();
-        //QString dateFormat = dialog.dateFormat();
-        //QString timeFormat = dialog.timeFormat();
-        //QString timestampFormat = dialog.timestampFormat();
+
 
         if (filename.isEmpty() || !m_query->isFinished() || !m_query->isSelect())
             return;
 
-        Csv csv(dialog.delimiter(), dialog.quoteSymbol());
+        //Csv(QString delimiter = ",", QString quote = "\"", bool includeHeader = true, bool quoteStringColumns = true, QLocale locale = QLocale::system(), QHash<QString, QString> formatOverrides = QHash<QString, QString>());
+        Csv csv(dialog.delimiter(), dialog.quoteSymbol(), dialog.includeHeader(), dialog.quoteStringColumns(), dialog.locale(), dialog.formatOverrides());
 
         ui->button_exportQueryResults->setEnabled(false);
         ui->button_stopExport->setEnabled(true);

--- a/ui/QueryTab.cpp
+++ b/ui/QueryTab.cpp
@@ -367,6 +367,10 @@ void QueryTab::on_button_exportQueryResults_released()
     if (dialog.exec() == QDialog::Accepted)
     {
         QString filename = dialog.outputFilePath();
+        //QString numberFormat = dialog.numberFormat();
+        //QString dateFormat = dialog.dateFormat();
+        //QString timeFormat = dialog.timeFormat();
+        //QString timestampFormat = dialog.timestampFormat();
 
         if (filename.isEmpty() || !m_query->isFinished() || !m_query->isSelect())
             return;

--- a/ui/TableView.cpp
+++ b/ui/TableView.cpp
@@ -18,7 +18,12 @@ void TableView::keyPressEvent(QKeyEvent *event)
     {
         if (event->matches(QKeySequence::Copy))
         {
+            //QHash<QString, QString> parameters;
+            //parameters["delimiter"] = "\t";
+            //parameters["quote"] = "\"";
+
             QString text = Csv("\t", "\"").writeSelectionToString(model(), selectionModel()->selection());
+
             QApplication::clipboard()->setText(text);
         }
         else

--- a/ui/TableView.cpp
+++ b/ui/TableView.cpp
@@ -18,11 +18,12 @@ void TableView::keyPressEvent(QKeyEvent *event)
     {
         if (event->matches(QKeySequence::Copy))
         {
-            //QHash<QString, QString> parameters;
-            //parameters["delimiter"] = "\t";
-            //parameters["quote"] = "\"";
+            QHash<QString, QString> parameters;
+            parameters["timeFormat"] = "HH:mm:ss";
+            parameters["timestampFormat"] = "yyyy-MM-ddTHH:mm:ss";
+            parameters["dateFormat"] = "yyyy-MM-dd";
 
-            QString text = Csv("\t", "\"").writeSelectionToString(model(), selectionModel()->selection());
+            QString text = Csv("\t", "\"", true, true, QLocale::system(), parameters).writeSelectionToString(model(), selectionModel()->selection());
 
             QApplication::clipboard()->setText(text);
         }


### PR DESCRIPTION
Add possibility to choose:
- custom formats for date, datetime and time
- include/exclude headers
- quoting symbol
- autosave custom formats (formats not taken from system locale)